### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.example</groupId>
     <artifactId>my-app</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -22,7 +17,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.9</version>
+            <version>5.3.41</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -170,7 +165,6 @@
             <version>3.1</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.12.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2020-36518 | High  | jackson-databind is a data-binding package for the Jackson<br>Data Processor. jackson-databind allows a Java stack overflow<br>exception and denial of service via a large depth of nested<br>objects. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42003 | High  | In FasterXML jackson-databind 2.4.0-rc1 until 2.12.7.1 and in<br>2.13.x before 2.13.4.2 resource exhaustion can occur because<br>of a lack of a check in primitive value deserializers to<br>avoid deep wrapper array nesting, when the<br>UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled. This was<br>patched in 2.12.7.1, 2.13.4.2, and 2.14.0. Commits that<br>introduced vulnerable code are<br>https://github.com/FasterXML/jackson-databind/commit/d499f2e7bbc5ebd63af11e1f5cf1989fa323aa45,<br>https://github.com/FasterXML/jackson-databind/commit/0e37a39502439ecbaa1a5b5188387c01bf7f7fa1,<br>and<br>https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc.<br>Fix commits are<br>https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea<br>and<br>https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33.<br>The `2.13.4.1` release does fix this issue, however it also<br>references a non-existent jackson-bom which causes build<br>failures for gradle users. See<br>https://github.com/FasterXML/jackson-databind/issues/3627#issuecomment-1277957548<br>for details. This is fixed in `2.13.4.2` which is listed in<br>the advisory metadata so that users are not subjected to<br>unnecessary build failures |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2022-42004 | High  | In FasterXML jackson-databind before 2.12.7.1 and in 2.13.x<br>before 2.13.4, resource exhaustion can occur because of a<br>lack of a check in BeanDeserializer._deserializeFromArray to<br>prevent use of deeply nested arrays. This issue can only<br>happen when the `UNWRAP_SINGLE_VALUE_ARRAYS` feature is<br>explicitly enabled. |
| com.fasterxml.jackson.core:jackson-databind:2.12.3 | CVE-2021-46877 | High  | jackson-databind 2.10.x through 2.12.x before 2.12.6 and<br>2.13.x before 2.13.1 allows attackers to cause a denial of<br>service (2 GB transient heap usage per read) in uncommon<br>situations involving JsonNode JDK serialization. |
| org.springframework:spring-core:5.3.9 | CVE-2021-22096 | Medium  | Improper Output Neutralization for Logs in Spring Framework |
| org.springframework:spring-core:5.3.9 | CVE-2021-22060 | Medium  | Log entry injection in Spring Framework |
| org.springframework:spring-core:5.3.9 | CVE-2025-41249 | High  | Spring Framework annotation detection mechanism may result in<br>improper authorization |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
